### PR TITLE
In the model, allow Actors to send and receive AppMessages.

### DIFF
--- a/model/distrib_cycle_detector.als
+++ b/model/distrib_cycle_detector.als
@@ -5,27 +5,51 @@ open pony/distrib_cycle_detector/StateChanges
 
 fact { always stateChange }
 
-run example for 8
-pred example {
-  ///
-  // Initial constraints
+one var sig Main in Actor {}
+lone var sig A in Actor {}
+lone var sig B in Actor {}
+lone var sig C in Actor {}
 
-  #Actor = 1
+fact "initial conditions" {
+  Actor = Main
   Actor.isActive = Actor // (all initial actors begin as active)
   no Actor.inMap
   no Actor.inMem
 
+  no AppMessage
   no Connection
   no Trace
+}
 
+run example for 4
+pred example {
   ///
   // Desired state change sequence, if any.
 
-  some StateChanges.willSpawnActorFrom
-  after some StateChanges.willReduceMemOf
-  after after some StateChanges.willSpawnActorFrom
-  after after after some StateChanges.willSpawnActorFrom
-  eventually some a: Actor | #a.inMap = 3
+  // some StateChanges.willSpawnActorFrom
+  // after some StateChanges.willSpawnActorFrom
+  // after after some StateChanges.willSendAppMessageFrom
+  // after after after some StateChanges.willSpawnActorFrom
+
+  ///
+  // Expected intermediate state, if any.
+
+  // Spawn a ring of 3 actors, all held by a Main actor.
+  eventually {
+    some A
+    some B
+    some C
+
+    Connection.from = Main
+    Connection.to = (A + B + C)
+
+    // Main holds a reference to all three of A, B, C.
+    // And each holds a reference to one of the others, in a ring.
+    Main.inMem = (A + B + C)
+    B.inMem = C
+    A.inMem = B
+    C.inMem = A
+  }
 
   ///
   // Safety checks.

--- a/model/distrib_cycle_detector/Models.als
+++ b/model/distrib_cycle_detector/Models.als
@@ -47,6 +47,30 @@ pred unchangedActors {
 }
 
 ///
+// An AppMessage carries application-level data from one Actor to another.
+
+var sig AppMessage {
+  // This is the recipient of the message.
+  var to: Actor,
+
+  // This is the set of actor references that are in the message arguments.
+  // For the purpose of this model we ignore the all other data in the message.
+  var inArgs: set Actor,
+}
+
+pred unchanged[m: AppMessage] {
+  m in AppMessage
+  m in AppMessage'
+  m.to' = m.to
+  m.inArgs' = m.inArgs
+}
+
+pred unchangedAppMessages {
+  AppMessage' = AppMessage
+  all m: AppMessage | unchanged[m]
+}
+
+///
 // A Connection represents one Actor's knowledge about another Actor.
 
 var sig Connection {

--- a/model/theme.thm
+++ b/model/theme.thm
@@ -12,6 +12,10 @@
    <type name="String"/>
    <type name="univ"/>
    <type name="seq/Int"/>
+   <set name="this/A" type="Models/Actor"/>
+   <set name="this/B" type="Models/Actor"/>
+   <set name="this/C" type="Models/Actor"/>
+   <set name="this/Main" type="Models/Actor"/>
 </node>
 
 <node shape="Box" color="Blue" label="TraceElement">
@@ -20,6 +24,10 @@
 
 <node shape="Ellipse" color="Yellow" label="Actor">
    <type name="Models/Actor"/>
+</node>
+
+<node shape="House" color="White" label="AppMessage">
+   <type name="Models/AppMessage"/>
 </node>
 
 <node shape="Lined Diamond" color="Gray" label="StateChanges">
@@ -46,6 +54,15 @@
 <edge style="inherit" visible="no" attribute="yes">
    <relation name="inMap"> <type name="Models/Actor"/> <type name="Models/Actor"/> </relation>
    <relation name="inMem"> <type name="Models/Actor"/> <type name="Models/Actor"/> </relation>
+</edge>
+
+<edge visible="no">
+   <relation name="isActive"> <type name="Models/Actor"/> <type name="Models/Actor"/> </relation>
+</edge>
+
+<edge visible="no" attribute="yes">
+   <relation name="inArgs"> <type name="Models/AppMessage"/> <type name="Models/Actor"/> </relation>
+   <relation name="to"> <type name="Models/Connection"/> <type name="Models/Actor"/> </relation>
 </edge>
 
 </view>


### PR DESCRIPTION
An AppMessage may have one or more Actor references in it, which were inMem for the sender, and become inMem for the receiver.

An AppMessage is sent in a separate step from being received, so other events may be interleaved between those steps.