### PR TITLE
In the model, Messages form a FIFO queue.

### DIFF
--- a/model/distrib_cycle_detector.als
+++ b/model/distrib_cycle_detector.als
@@ -9,6 +9,7 @@ one var sig Main in Actor {}
 lone var sig A in Actor {}
 lone var sig B in Actor {}
 lone var sig C in Actor {}
+fact { disj[Main, A, B, C] }
 
 fact "initial conditions" {
   Actor = Main
@@ -16,7 +17,7 @@ fact "initial conditions" {
   no Actor.inMap
   no Actor.inMem
 
-  no AppMessage
+  no Message
   no Connection
   no Trace
 }
@@ -56,4 +57,11 @@ pred example {
   // Enable one of these below to search for safety violations.
 
   // eventually not noDanglingActors
+}
+
+check actorQueueStructure for 2 but 5 Message, 7 steps
+assert actorQueueStructure {
+  // An Actor always has exactly one enqueue target, implying that it always
+  // can accept a message, and never has diverging/forking queues.
+  always all a: Actor | one a.enqueueTarget
 }

--- a/model/distrib_cycle_detector/Models.als
+++ b/model/distrib_cycle_detector/Models.als
@@ -46,22 +46,67 @@ pred unchangedActors {
   all a: Actor | unchanged[a]
 }
 
+fun enqueueTarget[a: Actor]: (Actor + Message) {
+  // Find the item in the Actor's queue that has nothing enqueued behind it.
+  // If the Actor has no Messages enqueued, this returns the Actor itself.
+  // In theory this could return more than one item (if the Actor had multiple
+  // or diverging queues) but because of the rest of the logic in the model,
+  // we don't expect that to happen
+  { t: a.*~enqueued | no t.~enqueued }
+}
+
+///
+// A Message goes into the FIFO message queue of an Actor.
+
+abstract var sig Message {
+  var enqueued: one (Actor + Message)
+}
+
+pred unchangedMessages {
+  unchangedAppMessages
+}
+
+pred sendTo[m: Message', a: Actor] {
+  // Put the message at the end of the Actor's queue.
+  m.enqueued' = a.enqueueTarget
+}
+
+pred receiveNow[message: Message] {
+  // Messages are a FIFO queue, so we can only process this message if it is
+  // enqueued to the Actor rather than enqueued "behind" another Message.
+  message.enqueued in Actor
+
+  // The next enqueued message becomes enqueued directly to the Actor,
+  // ready to be received next by the Actor.
+  message.enqueued.~enqueued' = message.~enqueued
+  unchangedExceptEnqueued[message.~enqueued]
+
+  // The message gets removed as it is received.
+  message not in Message'
+  Message' = Message - message
+
+  // All other messages are unchanged.
+  all existing: (Message - message - message.~enqueued) | unchanged[existing]
+}
+
+
 ///
 // An AppMessage carries application-level data from one Actor to another.
 
-var sig AppMessage {
-  // This is the recipient of the message.
-  var to: Actor,
-
+var sig AppMessage extends Message {
   // This is the set of actor references that are in the message arguments.
   // For the purpose of this model we ignore the all other data in the message.
   var inArgs: set Actor,
 }
 
 pred unchanged[m: AppMessage] {
+  m.unchangedExceptEnqueued
+  m.enqueued' = m.enqueued
+}
+
+pred unchangedExceptEnqueued[m: AppMessage] {
   m in AppMessage
   m in AppMessage'
-  m.to' = m.to
   m.inArgs' = m.inArgs
 }
 

--- a/model/theme.thm
+++ b/model/theme.thm
@@ -26,16 +26,17 @@
    <type name="Models/Actor"/>
 </node>
 
-<node shape="House" color="White" label="AppMessage">
-   <type name="Models/AppMessage"/>
-</node>
-
 <node shape="Lined Diamond" color="Gray" label="StateChanges">
    <type name="StateChanges/StateChanges"/>
 </node>
 
 <node shape="Parallelogram" color="Green" label="Connection">
    <type name="Models/Connection"/>
+</node>
+
+<node style="Dashed" shape="House" color="White" label="AppMessage">
+   <type name="Models/Message"/>
+   <type name="Models/AppMessage"/>
 </node>
 
 <node style="Solid" shape="Box" color="Blue" label="Trace">
@@ -51,7 +52,14 @@
    <relation name="prior"> <type name="Models/TraceElement"/> <type name="Models/TraceElement"/> </relation>
 </edge>
 
+<edge style="inherit">
+   <relation name="enqueued"> <type name="Models/Message"/> <type name="Models/Actor"/> </relation>
+   <relation name="enqueued"> <type name="Models/Message"/> <type name="Models/Message"/> </relation>
+   <relation name="willReceiveAppMessage"> <type name="StateChanges/StateChanges"/> <type name="Models/Message"/> </relation>
+</edge>
+
 <edge style="inherit" visible="no" attribute="yes">
+   <relation name="inArgs"> <type name="Models/Message"/> <type name="Models/Actor"/> </relation>
    <relation name="inMap"> <type name="Models/Actor"/> <type name="Models/Actor"/> </relation>
    <relation name="inMem"> <type name="Models/Actor"/> <type name="Models/Actor"/> </relation>
 </edge>
@@ -61,7 +69,6 @@
 </edge>
 
 <edge visible="no" attribute="yes">
-   <relation name="inArgs"> <type name="Models/AppMessage"/> <type name="Models/Actor"/> </relation>
    <relation name="to"> <type name="Models/Connection"/> <type name="Models/Actor"/> </relation>
 </edge>
 


### PR DESCRIPTION
Prior to this change, an Actor that received multiple messages and had not yet handled them could choose any available message to handle, leading to less determinism than we want to model for Actor messaging.

After this change, Messages are modeled as a FIFO queue on the Actor, and the Actor can only process the next immediate message in the queue.