### PR TITLE
In the model, Actors have ordered ids.

### DIFF
--- a/model/distrib_cycle_detector/Models.als
+++ b/model/distrib_cycle_detector/Models.als
@@ -1,9 +1,13 @@
+open util/integer
+
 module pony/distrib_cycle_detector/Models
 
 ///
 // An Actor is an entity that can send and receive messages.
 
 var sig Actor {
+  var id: disj one Int,
+
   var isActive: lone Actor,
   var isDestroyed: lone Actor,
 
@@ -28,6 +32,7 @@ fact "an actor always has exactly protocol status pointing to itself" {
 pred unchanged[a: Actor] {
   a in Actor
   a in Actor'
+  a.id' = a.id
   a.isActive' = a.isActive
   a.isDestroyed' = a.isDestroyed
   a.inMap' = a.inMap
@@ -37,6 +42,7 @@ pred unchanged[a: Actor] {
 pred unchangedExceptMapAndMem[a: Actor] {
   a in Actor
   a in Actor'
+  a.id' = a.id
   a.isActive' = a.isActive
   a.isDestroyed' = a.isDestroyed
 }
@@ -53,6 +59,10 @@ fun enqueueTarget[a: Actor]: (Actor + Message) {
   // or diverging queues) but because of the rest of the logic in the model,
   // we don't expect that to happen
   { t: a.*~enqueued | no t.~enqueued }
+}
+
+fun chooseLowestId[actors: Actor]: Actor {
+  { a: actors | a.id = min[actors.id] }
 }
 
 ///

--- a/model/theme.thm
+++ b/model/theme.thm
@@ -34,8 +34,11 @@
    <type name="Models/Connection"/>
 </node>
 
-<node style="Dashed" shape="House" color="White" label="AppMessage">
+<node shape="House" shape="House" color="White" label="Message">
    <type name="Models/Message"/>
+</node>
+
+<node style="Dashed" shape="House" color="White" label="AppMessage">
    <type name="Models/AppMessage"/>
 </node>
 
@@ -69,6 +72,7 @@
 </edge>
 
 <edge visible="no" attribute="yes">
+   <relation name="id"> <type name="Models/Actor"/> <type name="Int"/> </relation>
    <relation name="to"> <type name="Models/Connection"/> <type name="Models/Actor"/> </relation>
 </edge>
 


### PR DESCRIPTION
The protocol requires actors to be ordered by an identifier, so that leaders can be elected with only local knowledge (for example, by choosing the lowest id as the leader).